### PR TITLE
Refactor unused helpers and integrate features

### DIFF
--- a/app/src/main/java/com/playstudio/AITeacher/ChatFragment.kt
+++ b/app/src/main/java/com/playstudio/AITeacher/ChatFragment.kt
@@ -192,6 +192,7 @@ class ChatFragment : Fragment(), TextToSpeech.OnInitListener {
     private val MAX_API_KEY_ERRORS_BEFORE_UPDATE = 3
     private var outputFile: String = ""
     private var meetingTranscript = StringBuilder()
+    private var conversationHistory = JSONArray()
 
     // Web search related constants
     private val WEB_SEARCH_MODELS = listOf(
@@ -408,7 +409,7 @@ class ChatFragment : Fragment(), TextToSpeech.OnInitListener {
         super.onViewCreated(view, savedInstanceState)
         Log.d("ChatFragment", "onViewCreated called")
 
-        selectedVoice = loadSelectedVoice()
+        loadSharedPrefs()
         binding.voiceSelectionButton.text = "Voice: ${selectedVoice.replaceFirstChar { it.uppercase() }}"
 
         // Initialize the views
@@ -442,35 +443,7 @@ class ChatFragment : Fragment(), TextToSpeech.OnInitListener {
         }
 
         binding.voiceSelectionButton.setTextColor(ContextCompat.getColor(requireContext(), android.R.color.white))
-        // Initialize the chatAdapter with the lifecycleScope
-        // Initialize the chatAdapter
-        chatAdapter = com.playstudio.aiteacher.ChatAdapter(
-            onCitationClicked = { citation ->
-                showCitationDialog(citation)
-            },
-            onFollowUpQuestionClicked = { question ->
-                binding.messageEditText.setText(question)
-                binding.messageEditText.setSelection(question.length)
-                // Optionally, you might want to also send the message or hide keyboard
-            },
-            onLoadMoreRequested = {
-                // Check if already loading to prevent multiple requests
-                if (!isLoadingMoreMessages) {
-                    Log.d("ChatFragment", "onLoadMoreRequested triggered")
-                    loadOlderMessages()
-                }
-            }
-        )
-
-        binding.recyclerView.apply {
-            layoutManager = LinearLayoutManager(requireContext()).apply {
-                stackFromEnd = true
-            }
-            adapter = chatAdapter
-            setHasFixedSize(true)
-            itemAnimator = null // Or DefaultItemAnimator()
-            setItemViewCacheSize(20)
-        }
+        setupChatRecyclerView()
 
         binding.voiceSelectionButton.setOnClickListener {
             showVoiceSelectionDialog()
@@ -484,16 +457,6 @@ class ChatFragment : Fragment(), TextToSpeech.OnInitListener {
         }
 
 
-        // Set up the RecyclerView
-        binding.recyclerView.apply {
-            layoutManager = LinearLayoutManager(requireContext()).apply {
-                stackFromEnd = true // Ensure new messages appear at the bottom
-            }
-            adapter = chatAdapter
-            setHasFixedSize(true) // Optimize for fixed-size RecyclerView
-            itemAnimator = null // Disable item animations for better performance
-            setItemViewCacheSize(20) // Increase cache size for smoother scrolling
-        }
         // Load the isGreetingSent flag from SharedPreferences
         val sharedPreferences = requireContext().getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
         isGreetingSent = sharedPreferences.getBoolean(GREETING_SENT_KEY, false)
@@ -554,7 +517,7 @@ class ChatFragment : Fragment(), TextToSpeech.OnInitListener {
         // Initialize with the selected model
         arguments?.getString("selected_model")?.let {
             currentModel = it
-            updateUIForCurrentModel()
+            switchUiForModel(currentModel)
         }
         captureImageLauncher = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
             if (result.resultCode == Activity.RESULT_OK) {
@@ -985,31 +948,37 @@ class ChatFragment : Fragment(), TextToSpeech.OnInitListener {
         pickImageLauncher = registerForActivityResult(ActivityResultContracts.GetContent()) { uri: Uri? ->
             uri?.let { processSelectedFile(it) }
         }
-        pickDocumentLauncher = registerForActivityResult(ActivityResultContracts.OpenDocument()) { uri: Uri? ->
-            uri?.let { processSelectedFile(it) }
-        }
+    pickDocumentLauncher = registerForActivityResult(ActivityResultContracts.OpenDocument()) { uri: Uri? ->
+        uri?.let { processSelectedFile(it) }
     }
+}
 
-
-
-
-    private fun setupChatRecyclerView() {
-        chatAdapter = com.playstudio.aiteacher.ChatAdapter(
-            onCitationClicked = { showCitationDialog(it) },
-            onFollowUpQuestionClicked = { question ->
-                binding.messageEditText.setText(question)
-                // Optionally send message or just prefill
-            },
-            onLoadMoreRequested = {
-                // Implement if you have pagination
+private fun setupChatRecyclerView() {
+    chatAdapter = com.playstudio.aiteacher.ChatAdapter(
+        onCitationClicked = { showCitationDialog(it) },
+        onFollowUpQuestionClicked = { question ->
+            binding.messageEditText.setText(question)
+            binding.messageEditText.setSelection(question.length)
+        },
+        onLoadMoreRequested = {
+            if (!isLoadingMoreMessages) {
+                loadOlderMessages()
             }
-        )
-        binding.recyclerView.apply {
-            layoutManager = LinearLayoutManager(requireContext()).apply { stackFromEnd = true }
-            adapter = chatAdapter
-            // itemAnimator = null // Consider DefaultItemAnimator for better UX if no issues
         }
+    )
+
+    binding.recyclerView.apply {
+        layoutManager = LinearLayoutManager(requireContext()).apply { stackFromEnd = true }
+        adapter = chatAdapter
+        setHasFixedSize(true)
+        itemAnimator = null
+        setItemViewCacheSize(20)
     }
+}
+
+
+
+
 
     private fun setupUIListeners() {
         binding.sendButton.setOnClickListener {
@@ -1067,18 +1036,6 @@ class ChatFragment : Fragment(), TextToSpeech.OnInitListener {
 
     // In ChatFragment.kt
 
-    private fun checkAndRequestAudioPermission(requestCode: Int): Boolean { // requestCode can be used if you had different actions post-permission
-        return if (ContextCompat.checkSelfPermission(requireContext(), Manifest.permission.RECORD_AUDIO)
-            == PackageManager.PERMISSION_GRANTED
-        ) {
-            true // Permission is already granted
-        } else {
-            // Permission is not granted, request it using the launcher.
-            // The launcher's callback will handle the result.
-            requestAudioPermissionLauncher.launch(Manifest.permission.RECORD_AUDIO)
-            false // Permission was not granted at the time of this check
-        }
-    }
     private fun observeViewModels() {
         // OpenAI Live Audio ViewModel Observers
         viewLifecycleOwner.lifecycleScope.launch {
@@ -1125,16 +1082,6 @@ class ChatFragment : Fragment(), TextToSpeech.OnInitListener {
             updateSubscriptionStatus(subscriptionViewModel.isAdFree.value ?: false, expirationTime)
         }
     }
-    private fun loadSharedPrefs() {
-        val appPrefs = requireContext().getSharedPreferences(PREFS_NAME_APP, Context.MODE_PRIVATE)
-        selectedVoice = appPrefs.getString(SELECTED_VOICE_KEY, "alloy") ?: "alloy"
-        binding.voiceSelectionButton.text = "Voice: ${selectedVoice.replaceFirstChar { it.uppercase() }}"
-        // Load conversationId for the last session or default to a new one
-        conversationId = appPrefs.getString("last_conversation_id", null) ?: generateConversationId().also {
-            appPrefs.edit().putString("last_conversation_id", it).apply()
-        }
-        isFollowUpEnabled = appPrefs.getBoolean("follow_up_enabled", true)
-    }
     private fun isGreetingSentForCurrentConversation(): Boolean {
         val chatPrefs = requireContext().getSharedPreferences(PREFS_NAME_CHAT, Context.MODE_PRIVATE)
         return chatPrefs.getBoolean(KEY_GREETING_SENT + conversationId, false)
@@ -1145,11 +1092,18 @@ class ChatFragment : Fragment(), TextToSpeech.OnInitListener {
         chatPrefs.edit().putBoolean(KEY_GREETING_SENT + conversationId, true).apply()
     }
 
+    private fun loadSharedPrefs() {
+        val appPrefs = requireContext().getSharedPreferences(PREFS_NAME_APP, Context.MODE_PRIVATE)
+        selectedVoice = appPrefs.getString(SELECTED_VOICE_KEY, "alloy") ?: "alloy"
+        conversationId = appPrefs.getString("last_conversation_id", null) ?: generateConversationId().also {
+            appPrefs.edit().putString("last_conversation_id", it).apply()
+        }
+        isFollowUpEnabled = appPrefs.getBoolean("follow_up_enabled", true)
+    }
 
 
-    // Updated ChatFragment methods for computer use
 
-    private var conversationHistory = JSONArray()
+
 
 
 
@@ -1808,16 +1762,13 @@ class ChatFragment : Fragment(), TextToSpeech.OnInitListener {
         }
     }
 
-    // This would be called by a UI button or potentially another AI tool ("stop_meeting_recording")
-// For now, let's assume a UI button calls a public method in the fragment, which then calls this.
-// This function is NOT directly called by the AI in the initial tool flow.
     suspend fun processAndSummarizeMeeting(): String? = withContext(Dispatchers.IO) {
         if (!isMeetingRecording && currentMeetingAudioFile == null) {
             Log.w("ChatFragmentTool", "No active recording or file to summarize.")
-            return@withContext null // Or an error string
+            return@withContext null
         }
 
-        if (isMeetingRecording) { // Stop it first if still running
+        if (isMeetingRecording) {
             try {
                 mediaRecorder?.stop()
                 mediaRecorder?.release()
@@ -1829,7 +1780,7 @@ class ChatFragment : Fragment(), TextToSpeech.OnInitListener {
         }
 
         val fileToSummarize = currentMeetingAudioFile
-        currentMeetingAudioFile = null // Reset for next recording
+        currentMeetingAudioFile = null
 
         if (fileToSummarize == null || !fileToSummarize.exists() || fileToSummarize.length() == 0L) {
             Log.e("ChatFragmentTool", "Meeting audio file is invalid or empty for summarization.")
@@ -1837,28 +1788,26 @@ class ChatFragment : Fragment(), TextToSpeech.OnInitListener {
         }
 
         Log.i("ChatFragmentTool", "Processing meeting recording for summarization: ${fileToSummarize.absolutePath}")
-        showCustomToast("Processing meeting summary...") // Show on UI thread
+        showCustomToast("Processing meeting summary...")
 
-        // Step 1: Transcribe (using OpenAI Audio API - 'whisper-1' or similar)
         val transcript: String? = try {
             val requestFile = fileToSummarize.asRequestBody("audio/m4a".toMediaTypeOrNull())
             val requestBody = MultipartBody.Builder()
                 .setType(MultipartBody.FORM)
                 .addFormDataPart("file", fileToSummarize.name, requestFile)
-                .addFormDataPart("model", "whisper-1") // Or your preferred transcription model
-                // .addFormDataPart("response_format", "json") // 'json' gives structured output with text
+                .addFormDataPart("model", "whisper-1")
                 .build()
 
             val request = Request.Builder()
                 .url("https://api.openai.com/v1/audio/transcriptions")
-                .header("Authorization", "Bearer ${BuildConfig.API_KEY}") // Ensure BuildConfig.API_KEY is OpenAI key
+                .header("Authorization", "Bearer ${BuildConfig.API_KEY}")
                 .post(requestBody)
                 .build()
 
             val response = okHttpClient.newCall(request).execute()
             if (response.isSuccessful) {
-                val responseBody = response.body?.string()
-                responseBody?.let { JSONObject(it).getString("text") }
+                val body = response.body?.string()
+                body?.let { JSONObject(it).getString("text") }
             } else {
                 Log.e("ChatFragmentTool", "Transcription API error: ${response.code} - ${response.message}")
                 null
@@ -1869,25 +1818,22 @@ class ChatFragment : Fragment(), TextToSpeech.OnInitListener {
         }
 
         if (transcript.isNullOrBlank()) {
-            Log.e("ChatFragmentTool", "Transcription failed or produced empty text.")
-            fileToSummarize.delete() // Clean up
+            fileToSummarize.delete()
             return@withContext JSONObject().apply { put("error", "Failed to transcribe the meeting audio.") }.toString()
         }
 
-        Log.i("ChatFragmentTool", "Transcription successful. Length: ${transcript.length}")
-        fileToSummarize.delete() // Clean up original audio file after successful transcription
+        fileToSummarize.delete()
 
-        // Step 2: Summarize (using OpenAI Chat Completions API)
         val summaryPrompt = "Please provide a concise summary of the following meeting transcript:\n\nTranscript:\n\"\"\"\n$transcript\n\"\"\"\n\nSummary:"
         val messagesArray = JSONArray().put(JSONObject().apply {
             put("role", "user")
             put("content", summaryPrompt)
         })
         val summaryRequestBodyJson = JSONObject().apply {
-            put("model", "gpt-3.5-turbo") // Or gpt-4o for better summaries
+            put("model", "gpt-3.5-turbo")
             put("messages", messagesArray)
             put("temperature", 0.5)
-            put("max_tokens", 300) // Adjust as needed
+            put("max_tokens", 300)
         }
         val summaryBody = summaryRequestBodyJson.toString().toRequestBody("application/json".toMediaTypeOrNull())
         val summaryRequest = Request.Builder()
@@ -1903,9 +1849,7 @@ class ChatFragment : Fragment(), TextToSpeech.OnInitListener {
                 val summaryResponseBody = summaryResponse.body?.string()
                 summaryResponseBody?.let {
                     val summaryText = JSONObject(it).getJSONArray("choices").getJSONObject(0).getJSONObject("message").getString("content").trim()
-                    Log.i("ChatFragmentTool", "Summarization successful.")
-                    // Return the summary text itself. The calling UI logic will add it to chat.
-                    return@withContext summaryText // Just the summary string
+                    return@withContext summaryText
                 }
             } else {
                 Log.e("ChatFragmentTool", "Summarization API error: ${summaryResponse.code} - ${summaryResponse.message}")
@@ -1913,8 +1857,9 @@ class ChatFragment : Fragment(), TextToSpeech.OnInitListener {
         } catch (e: Exception) {
             Log.e("ChatFragmentTool", "Exception during summarization: ${e.message}", e)
         }
-        return@withContext JSONObject().apply { put("error", "Failed to summarize the meeting.") }.toString() // Fallback error
+        JSONObject().apply { put("error", "Failed to summarize the meeting.") }.toString()
     }
+
 
 
 
@@ -2869,27 +2814,6 @@ class ChatFragment : Fragment(), TextToSpeech.OnInitListener {
 
         return builder.toString()
     }
-    private fun addMessageToChat(
-        messageContent: String,
-        isUser: Boolean,
-        citations: List<com.playstudio.aiteacher.ChatFragment.Citation> = emptyList(),
-        followUpQuestions: List<String> = emptyList(),
-        containsRichContent: Boolean = false // Pass this flag
-    ) {
-        val newChatMessage = ChatMessage(
-            id = System.currentTimeMillis().toString(),
-            content = messageContent,
-            isUser = isUser,
-            citations = citations,
-            followUpQuestions = followUpQuestions,
-            containsRichContent = containsRichContent
-        )
-        addMessageToList(newChatMessage)
-
-        if (!isUser && isTtsEnabled) {
-            speakOut(messageContent)
-        }
-    }
 
 
     private fun generateDynamicFollowUpQuestions(reply: String, callback: (List<String>) -> Unit) {
@@ -2962,18 +2886,18 @@ class ChatFragment : Fragment(), TextToSpeech.OnInitListener {
             }
         }
     }
+    private fun playAudioFromFile(file: File) {
+        MediaPlayer().apply {
+            setDataSource(file.absolutePath)
+            prepare()
+            start()
+        }
+    }
+
     private fun handleNetworkError(e: IOException) {
         lifecycleScope.launch(Dispatchers.Main) {
             showCustomToast("Network error: ${e.message}")
             removeTypingIndicator()
-        }
-    }
-
-    private fun playAudioFromFile(file: File) {
-        val mediaPlayer = MediaPlayer().apply {
-            setDataSource(file.absolutePath)
-            prepare()
-            start()
         }
     }
 
@@ -3013,13 +2937,10 @@ class ChatFragment : Fragment(), TextToSpeech.OnInitListener {
                     Log.d("ChatFragment", "Retrying image generation... Attempts left: $retryCount")
                     handleImageGeneration(prompt, retryCount - 1)
                 } else {
-                    Log.e("ChatFragment", "Failed to get image generation response", e)
+                    handleNetworkError(e)
                     requireActivity().runOnUiThread {
-                        showCustomToast("Failed to generate image. Please check your internet connection.")
                         binding.generatingText.visibility = View.GONE
                         binding.downloadButton.visibility = View.GONE
-
-                        // Stop the "Generating..." animation on failure
                         stopGeneratingAnimation()
                     }
                 }
@@ -3168,6 +3089,24 @@ class ChatFragment : Fragment(), TextToSpeech.OnInitListener {
         dialog.show()
     }
 
+    private fun showSubscriptionRequiredDialog() {
+        AlertDialog.Builder(requireContext())
+            .setTitle("Subscription Required")
+            .setMessage("This feature requires an active subscription")
+            .setPositiveButton("Subscribe") { _, _ ->
+                subscriptionClickListener?.onSubscriptionClick()
+            }
+            .setNegativeButton("Cancel", null)
+            .show()
+    }
+
+    private fun handleDalle3Request(message: String) {
+        addMessageToChat(message, true)
+        handleImageGeneration(message)
+        binding.messageEditText.text.clear()
+        incrementModelUsage("dall-e-3")
+    }
+
     private fun startGeneratingAnimation() {
         val blinkAnimation = AnimationUtils.loadAnimation(requireContext(), R.anim.blink)
         binding.generatingText.startAnimation(blinkAnimation)
@@ -3258,10 +3197,7 @@ class ChatFragment : Fragment(), TextToSpeech.OnInitListener {
         when (currentModel) {
             "dall-e-3" -> {
                 if (checkDailyLimit("dall-e-3", DAILY_LIMIT_DALLE)) {
-                    addMessageToChat(message, true)
-                    handleImageGeneration(message)
-                    binding.messageEditText.text.clear()
-                    incrementModelUsage("dall-e-3")
+                    handleDalle3Request(message)
                 } else {
                     showCustomToast("Daily limit for DALL-E 3 reached.")
                 }
@@ -3317,24 +3253,6 @@ class ChatFragment : Fragment(), TextToSpeech.OnInitListener {
         }
     }
 
-    private fun handleDalle3Request(message: String) {
-        addMessageToChat(message, true)
-        handleImageGeneration(message)
-        binding.messageEditText.text.clear()
-        incrementModelUsage("dall-e-3")
-    }
-
-    private fun showSubscriptionRequiredDialog() {
-        AlertDialog.Builder(requireContext())
-            .setTitle("Subscription Required")
-            .setMessage("This feature requires an active subscription")
-            .setPositiveButton("Subscribe") { _, _ ->
-                subscriptionClickListener?.onSubscriptionClick()
-            }
-            .setNegativeButton("Cancel", null)
-            .show()
-    }
-
     // In ChatFragment.kt - THIS IS THE VERSION TO KEEP AND USE
     private fun addMessageToChat(
         messageContent: String,
@@ -3356,6 +3274,11 @@ class ChatFragment : Fragment(), TextToSpeech.OnInitListener {
         )
         addMessageToList(newChatMessage) // Your helper that calls submitList
 
+        conversationHistory.put(JSONObject().apply {
+            put("role", if (isUser) "user" else "assistant")
+            put("content", messageContent)
+        })
+
         if (!isUser && isTtsEnabled) {
             speakOut(messageContent)
         }
@@ -3374,11 +3297,6 @@ class ChatFragment : Fragment(), TextToSpeech.OnInitListener {
             "$baseResponse<br>As an AI, I am text-based and cannot provide clickable links or visual content directly. However, you can find relevant diagrams and sketches by visiting: <a href=\"$searchUrl\">this link</a>."
         } else {
             baseResponse
-        }
-    }
-    private fun speakOut(text: String) {
-        if (isTtsEnabled) {
-            tts?.speak(text, TextToSpeech.QUEUE_FLUSH, null, "")
         }
     }
 
@@ -3780,89 +3698,15 @@ class ChatFragment : Fragment(), TextToSpeech.OnInitListener {
 
                 currentModel = selectedModelIdentifier // Update the fragment's currentModel
 
-                // --- UI Toggling Logic ---
-                when (currentModel) {
-                    "gemini-voice-chat" -> {
+                switchUiForModel(currentModel)
+                val displayName = if (position < options.size) options[position].substringBefore(" -") else "Chat"
+                updateActiveModelButton(displayName)
+                showCustomToast("Switched to $displayName")
 
-                        binding.openaiLiveAudioControls.visibility = View.GONE // Hide OpenAI controls
-
-                        // Hide standard text chat UI
-                        binding.messageInputLayout.visibility = View.GONE
-                        binding.scanTextButton.visibility = View.GONE
-                        binding.voiceInputButton.visibility = View.GONE // Standard STT
-                        binding.sendButton.visibility = View.GONE
-                        binding.ttsToggleButton.visibility = View.GONE // Standard TTS toggle
-                        binding.followUpQuestionsContainer.visibility = View.GONE
-                        binding.generatedImageView.visibility = View.GONE
-                        binding.downloadButton.visibility = View.GONE
-                        binding.generatingText.visibility = View.GONE
-
-
-                        updateActiveModelButton("Gemini Voice")
-                        showCustomToast("Switched to Gemini Voice Chat")
-                    }
-                    "openai-realtime-voice" -> {
-                        binding.openaiLiveAudioControls.visibility = View.VISIBLE
-
-
-
-                        // Hide standard text chat UI
-                        binding.messageInputLayout.visibility = View.GONE
-                        binding.scanTextButton.visibility = View.GONE
-                        binding.voiceInputButton.visibility = View.GONE
-                        binding.sendButton.visibility = View.GONE
-                        binding.ttsToggleButton.visibility = View.GONE
-                        binding.followUpQuestionsContainer.visibility = View.GONE
-                        binding.generatedImageView.visibility = View.GONE
-                        binding.downloadButton.visibility = View.GONE
-                        binding.generatingText.visibility = View.GONE
-
-                        openAILiveAudioViewModel.stopSession() // Ensure OpenAI session is stopped (will be started by user action)
-                        updateActiveModelButton("OpenAI Voice")
-                        showCustomToast("Switched to OpenAI Realtime Voice")
-                    }
-                    "computer-use-preview" -> {
-                        binding.computerUseControls.visibility = View.VISIBLE
-                        binding.messageInputLayout.visibility = View.VISIBLE
-                        binding.sendButton.visibility = View.GONE
-                        binding.scanTextButton.visibility = View.GONE
-                        binding.voiceInputButton.visibility = View.GONE
-                        binding.ttsToggleButton.visibility = View.GONE
-                        binding.followUpQuestionsContainer.visibility = View.GONE
-                        binding.generatedImageView.visibility = View.GONE
-                        binding.downloadButton.visibility = View.GONE
-                        binding.generatingText.visibility = View.GONE
-                        updateActiveModelButton("Computer Use")
-                        showCustomToast("Switched to Computer Use")
-                    }
-                    else -> {
-                        // Standard Text-Based Chat UI (for all other models)
-
-                        binding.openaiLiveAudioControls.visibility = View.GONE
-
-                        // Show standard text chat UI elements
-                        binding.messageInputLayout.visibility = View.VISIBLE
-                        binding.scanTextButton.visibility = View.VISIBLE
-                        binding.voiceInputButton.visibility = View.VISIBLE
-                        binding.sendButton.visibility = View.VISIBLE
-                        binding.ttsToggleButton.visibility = View.VISIBLE
-
-                        // Update active model button text from the options list
-                        val displayName = if (position < options.size) options[position].substringBefore(" -") else "Chat"
-                        updateActiveModelButton(displayName)
-                        showCustomToast("Switched to $displayName")
-
-                        // Call your existing function to set up UI for specific models (like DALL-E)
-                        updateUIForCurrentModel() // This handles DALL-E image view etc.
-                    }
-                }
-                // --- End UI Toggling Logic ---
-
-                // Common for all successful switches if not handled inside when cases
-                // binding.webSearchToggle.isEnabled = WEB_SEARCH_MODELS.contains(currentModel) // If you have this
+                // binding.webSearchToggle.isEnabled = WEB_SEARCH_MODELS.contains(currentModel)
 
             } else {
-                showSubscriptionDialog()
+                showSubscriptionRequiredDialog()
             }
             dialog.dismiss()
         }
@@ -4158,17 +4002,87 @@ class ChatFragment : Fragment(), TextToSpeech.OnInitListener {
         binding.subscriptionOverlay.visibility = View.GONE
     }
 
-    private fun updateActiveModelButton(modelName: String) {
-        binding.activeModelButton.text = modelName
+private fun updateActiveModelButton(modelName: String) {
+    binding.activeModelButton.text = modelName
+}
+
+
+    // --------------------------
+    // Voice and Speech Functions
+    // --------------------------
+
+    private fun checkAndRequestAudioPermission(requestCode: Int): Boolean {
+        return if (ContextCompat.checkSelfPermission(requireContext(), Manifest.permission.RECORD_AUDIO)
+            == PackageManager.PERMISSION_GRANTED
+        ) {
+            true
+        } else {
+            requestAudioPermissionLauncher.launch(Manifest.permission.RECORD_AUDIO)
+            false
+        }
     }
 
+    private fun initializeSpeechRecognizer() {
+        if (SpeechRecognizer.isRecognitionAvailable(requireContext())) {
+            speechRecognizer = SpeechRecognizer.createSpeechRecognizer(requireContext())
+            speechRecognizer?.setRecognitionListener(object : RecognitionListener {
+                override fun onReadyForSpeech(params: Bundle?) {
+                    showCustomToast("Listening...")
+                }
+
+                override fun onBeginningOfSpeech() {
+                    binding.voiceInputButton.text = "🛑"
+                }
+
+                override fun onRmsChanged(rmsdB: Float) {}
+
+                override fun onBufferReceived(buffer: ByteArray?) {}
+
+                override fun onEndOfSpeech() {
+                    binding.voiceInputButton.text = "🎤"
+                }
+
+                override fun onError(error: Int) {
+                    showCustomToast("Error: $error")
+                    binding.voiceInputButton.text = "🎤"
+                }
+
+                override fun onResults(results: Bundle?) {
+                    val matches = results?.getStringArrayList(SpeechRecognizer.RESULTS_RECOGNITION)
+                    if (!matches.isNullOrEmpty()) {
+                        binding.messageEditText.setText(matches[0])
+                        binding.messageEditText.setSelection(matches[0].length)
+                    }
+                }
+
+                override fun onPartialResults(partialResults: Bundle?) {}
+
+                override fun onEvent(eventType: Int, params: Bundle?) {}
+            })
+        } else {
+            showCustomToast("Speech recognition is not available on this device.")
+        }
+    }
+
+    private fun startVoiceRecognition() {
+        val intent = Intent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH).apply {
+            putExtra(RecognizerIntent.EXTRA_LANGUAGE_MODEL, RecognizerIntent.LANGUAGE_MODEL_FREE_FORM)
+            putExtra(RecognizerIntent.EXTRA_LANGUAGE, Locale.getDefault())
+            putExtra(RecognizerIntent.EXTRA_PROMPT, "Speak now...")
+        }
+        try {
+            startActivityForResult(intent, REQUEST_CODE_SPEECH_INPUT)
+        } catch (e: ActivityNotFoundException) {
+            showCustomToast("Speech recognition not supported on this device")
+        }
+    }
 
     private fun handleTextToSpeech(text: String) {
         if (isTtsEnabled) {
             val json = JSONObject().apply {
                 put("model", "tts-1")
                 put("input", text)
-                put("voice", selectedVoice) // Use the selected voice
+                put("voice", selectedVoice)
             }
 
             val body = json.toString().toRequestBody("application/json; charset=utf-8".toMediaTypeOrNull())
@@ -4211,6 +4125,73 @@ class ChatFragment : Fragment(), TextToSpeech.OnInitListener {
             })
         }
     }
+
+    private fun speakOut(text: String) {
+        if (isTtsEnabled) {
+            tts?.speak(text, TextToSpeech.QUEUE_FLUSH, null, "")
+        }
+    }
+
+    private fun updateSelectedVoice(voice: String) {
+        selectedVoice = voice
+        saveSelectedVoice(voice)
+        binding.voiceSelectionButton.text = "🎙️ ${voice.replaceFirstChar { it.uppercase() }}"
+    }
+
+    private fun updateTtsButtonState() {
+        binding.ttsToggleButton.apply {
+            backgroundTintList = ColorStateList.valueOf(
+                ContextCompat.getColor(
+                    context,
+                    if (isTtsEnabled) R.color.greenn else R.color.card_surface
+                )
+            )
+            isChecked = isTtsEnabled
+        }
+    }
+
+    private fun showVoiceSelectionDialog() {
+        val voices = arrayOf("Alloy", "Echo", "Fable", "Onyx", "Nova", "Shimmer")
+        val builder = AlertDialog.Builder(requireContext())
+        builder.setTitle("Select TTS Voice")
+        builder.setItems(voices) { _, which ->
+            val selectedVoice = voices[which].lowercase(Locale.ROOT)
+            updateSelectedVoice(selectedVoice)
+            showCustomToast("Selected voice: ${voices[which]}")
+        }
+        builder.setNegativeButton("Cancel", null)
+        builder.show()
+    }
+
+    private var selectedVoice = "alloy"
+    private val SELECTED_VOICE_KEY = "selected_voice"
+
+    private fun saveSelectedVoice(voice: String) {
+        val sharedPreferences = requireContext().getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        sharedPreferences.edit().putString(SELECTED_VOICE_KEY, voice).apply()
+    }
+
+    private fun loadSelectedVoice(): String {
+        val sharedPreferences = requireContext().getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        return sharedPreferences.getString(SELECTED_VOICE_KEY, "alloy") ?: "alloy"
+    }
+
+    override fun onInit(status: Int) {
+        if (status == TextToSpeech.SUCCESS) {
+            val result = tts?.setLanguage(Locale.US)
+            if (result == TextToSpeech.LANG_MISSING_DATA || result == TextToSpeech.LANG_NOT_SUPPORTED) {
+                Log.e("ChatFragment", "Language not supported")
+                showCustomToast("TTS language not supported")
+            } else {
+                Log.d("ChatFragment", "TTS initialized successfully")
+            }
+        } else {
+            Log.e("ChatFragment", "TTS initialization failed")
+            showCustomToast("TTS initialization failed")
+        }
+    }
+
+
 
     private fun sendImageToOpenAI(bitmap: Bitmap) {
         val base64Image = encodeImageToBase64(bitmap)
@@ -4376,59 +4357,6 @@ class ChatFragment : Fragment(), TextToSpeech.OnInitListener {
         val end = binding.messageEditText.selectionEnd
         binding.messageEditText.text.delete(start, end)
         showCustomToast("Text deleted")
-    }
-    private fun initializeSpeechRecognizer() {
-        if (SpeechRecognizer.isRecognitionAvailable(requireContext())) {
-            speechRecognizer = SpeechRecognizer.createSpeechRecognizer(requireContext())
-            speechRecognizer?.setRecognitionListener(object : RecognitionListener {
-                override fun onReadyForSpeech(params: Bundle?) {
-                    showCustomToast("Listening...")
-                }
-
-                override fun onBeginningOfSpeech() {
-                    binding.voiceInputButton.text = "🛑"
-                }
-
-                override fun onRmsChanged(rmsdB: Float) {}
-
-                override fun onBufferReceived(buffer: ByteArray?) {}
-
-                override fun onEndOfSpeech() {
-                    binding.voiceInputButton.text = "🎤"
-                }
-
-                override fun onError(error: Int) {
-                    showCustomToast("Error: $error")
-                    binding.voiceInputButton.text = "🎤"
-                }
-
-                override fun onResults(results: Bundle?) {
-                    val matches = results?.getStringArrayList(SpeechRecognizer.RESULTS_RECOGNITION)
-                    if (!matches.isNullOrEmpty()) {
-                        binding.messageEditText.setText(matches[0])
-                        binding.messageEditText.setSelection(matches[0].length)
-                    }
-                }
-
-                override fun onPartialResults(partialResults: Bundle?) {}
-
-                override fun onEvent(eventType: Int, params: Bundle?) {}
-            })
-        } else {
-            showCustomToast("Speech recognition is not available on this device.")
-        }
-    }
-    private fun startVoiceRecognition() {
-        val intent = Intent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH).apply {
-            putExtra(RecognizerIntent.EXTRA_LANGUAGE_MODEL, RecognizerIntent.LANGUAGE_MODEL_FREE_FORM)
-            putExtra(RecognizerIntent.EXTRA_LANGUAGE, Locale.getDefault())
-            putExtra(RecognizerIntent.EXTRA_PROMPT, "Speak now...")
-        }
-        try {
-            startActivityForResult(intent, REQUEST_CODE_SPEECH_INPUT)
-        } catch (e: ActivityNotFoundException) {
-            showCustomToast("Speech recognition not supported on this device")
-        }
     }
 
 
@@ -4612,28 +4540,6 @@ class ChatFragment : Fragment(), TextToSpeech.OnInitListener {
         }
     }
 
-    private fun updateSelectedVoice(voice: String) {
-        selectedVoice = voice
-        saveSelectedVoice(voice)
-        binding.voiceSelectionButton.text = "🎙️ ${voice.replaceFirstChar { it.uppercase() }}"
-    }
-
-
-
-    private fun updateTtsButtonState() {
-        binding.ttsToggleButton.apply {
-            // For ToggleButton, use setBackgroundTintList
-            backgroundTintList = ColorStateList.valueOf(
-                ContextCompat.getColor(
-                    context,
-                    if (isTtsEnabled) R.color.greenn else R.color.card_surface
-                )
-            )
-
-            // ToggleButton handles text automatically
-            isChecked = isTtsEnabled
-        }
-    }
 
     private fun hideKeyboard() {
         val imm = requireActivity().getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
@@ -4646,23 +4552,16 @@ class ChatFragment : Fragment(), TextToSpeech.OnInitListener {
         }
     }
 
-    override fun onInit(status: Int) {
-        if (status == TextToSpeech.SUCCESS) {
-            val result = tts?.setLanguage(Locale.US)
-            if (result == TextToSpeech.LANG_MISSING_DATA || result == TextToSpeech.LANG_NOT_SUPPORTED) {
-                Log.e("ChatFragment", "Language not supported")
-                showCustomToast("TTS language not supported")
-            } else {
-                Log.d("ChatFragment", "TTS initialized successfully")
-            }
-        } else {
-            Log.e("ChatFragment", "TTS initialization failed")
-            showCustomToast("TTS initialization failed")
-        }
-    }
 
     override fun onDestroyView() {
         super.onDestroyView()
+        if (isMeetingRecording || currentMeetingAudioFile != null) {
+            lifecycleScope.launch {
+                processAndSummarizeMeeting()?.let { summary ->
+                    addMessageToChat(summary, false)
+                }
+            }
+        }
         _binding = null
         tts?.stop()
         tts?.shutdown()
@@ -5011,32 +4910,6 @@ class ChatFragment : Fragment(), TextToSpeech.OnInitListener {
         dialog.show()
     }
 
-    private fun showVoiceSelectionDialog() {
-        val voices = arrayOf("Alloy", "Echo", "Fable", "Onyx", "Nova", "Shimmer")
-        val builder = AlertDialog.Builder(requireContext())
-        builder.setTitle("Select TTS Voice")
-        builder.setItems(voices) { dialog, which ->
-            val selectedVoice = voices[which].lowercase(Locale.ROOT)
-            updateSelectedVoice(selectedVoice)
-            showCustomToast("Selected voice: ${voices[which]}")
-        }
-        builder.setNegativeButton("Cancel", null)
-        builder.show()
-    }
-
-    private var selectedVoice = "alloy" // Default voice
-
-    private val SELECTED_VOICE_KEY = "selected_voice"
-
-    private fun saveSelectedVoice(voice: String) {
-        val sharedPreferences = requireContext().getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
-        sharedPreferences.edit().putString(SELECTED_VOICE_KEY, voice).apply()
-    }
-
-    private fun loadSelectedVoice(): String {
-        val sharedPreferences = requireContext().getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
-        return sharedPreferences.getString(SELECTED_VOICE_KEY, "alloy") ?: "alloy"
-    }
 
     // In ChatFragment.kt
 
@@ -5278,30 +5151,6 @@ class ChatFragment : Fragment(), TextToSpeech.OnInitListener {
 
 
             // Add other permission request codes here as needed
-        }
-    }
-    private fun checkAndRequestPermissions(permissions: Array<String>, requestCode: Int) {
-        val permissionsToRequest = permissions.filter {
-            ContextCompat.checkSelfPermission(requireContext(), it) != PackageManager.PERMISSION_GRANTED
-        }.toTypedArray()
-
-        if (permissionsToRequest.isNotEmpty()) {
-            requestPermissions(permissionsToRequest, requestCode)
-        } else {
-            onPermissionsGranted(requestCode)
-        }
-    }
-
-    private fun onPermissionsGranted(requestCode: Int) {
-        when (requestCode) {
-            CAMERA_REQUEST_CODE -> dispatchTakePictureIntent()
-            WRITE_EXTERNAL_STORAGE_PERMISSION_REQUEST_CODE -> {
-                val imageUrl = binding.imageContainer.getTag(R.id.image_url) as? String
-                if (imageUrl != null) {
-                    downloadImage(imageUrl)
-                }
-            }
-            PICK_DOCUMENT_REQUEST_CODE -> openDocumentPicker()
         }
     }
 


### PR DESCRIPTION
## Summary
- restored helper methods removed previously
- hooked up missing UI helpers like permission loading and DALL·E requests
- connected meeting summarization on fragment teardown
- centralized RecyclerView setup and model switching logic

## Testing
- ❌ `./gradlew --version` (failed: No route to host)

------
https://chatgpt.com/codex/tasks/task_b_683de6a9b6c48325b134562088b3fff5