### PR TITLE
Enable voice-driven tool usage

### DIFF
--- a/app/src/main/java/com/playstudio/AITeacher/ChatFragment.kt
+++ b/app/src/main/java/com/playstudio/AITeacher/ChatFragment.kt
@@ -526,7 +526,7 @@ class ChatFragment : Fragment(), VoiceToolHandler {
             viewLifecycleOwner.lifecycleScope.launch {
                 handleTextToSpeech(getString(R.string.voice_greeting), force = true)
                 delay(4000)
-                showVoiceFeaturesDialog()
+                showPromotionDialog()
             }
             sharedPreferences.edit()
                 .putBoolean(FIRST_LAUNCH_KEY, false)
@@ -3081,12 +3081,13 @@ class ChatFragment : Fragment(), VoiceToolHandler {
         dialog.show()
     }
 
-    private fun showVoiceFeaturesDialog() {
-        val view = LayoutInflater.from(requireContext()).inflate(R.layout.dialog_voice_features, null)
+    private fun showPromotionDialog() {
+        val view = LayoutInflater.from(requireContext()).inflate(R.layout.dialog_promotion, null)
+        view.findViewById<TextView>(R.id.promotionMessage).text = getString(R.string.voice_features_dialog_message)
         val dialog = AlertDialog.Builder(requireContext())
             .setView(view)
             .create()
-        view.findViewById<Button>(R.id.btn_close_voice).setOnClickListener { dialog.dismiss() }
+        view.findViewById<Button>(R.id.btnClose).setOnClickListener { dialog.dismiss() }
         dialog.show()
     }
 
@@ -3101,7 +3102,7 @@ class ChatFragment : Fragment(), VoiceToolHandler {
             else -> 0
         }
         if (milestone > 0 && milestone > shownLevel) {
-            showVoiceFeaturesDialog()
+            showPromotionDialog()
             prefs.edit().putInt(VOICE_PROMO_LEVEL_KEY, milestone).apply()
         }
     }

--- a/app/src/main/java/com/playstudio/AITeacher/ChatFragment.kt
+++ b/app/src/main/java/com/playstudio/AITeacher/ChatFragment.kt
@@ -119,10 +119,11 @@ import android.view.accessibility.AccessibilityManager
 import kotlinx.coroutines.suspendCancellableCoroutine
 import okhttp3.RequestBody.Companion.asRequestBody
 import kotlin.coroutines.resume
+import com.playstudio.aiteacher.VoiceToolHandler
 
 
 
-class ChatFragment : Fragment() {
+class ChatFragment : Fragment(), VoiceToolHandler {
     // Add this data class inside your ChatFragment class
     data class Citation(
         val url: String,
@@ -420,6 +421,9 @@ class ChatFragment : Fragment() {
 
         selectedVoice = loadSelectedVoice()
         binding.voiceSelectionButton.text = "Voice: ${selectedVoice.replaceFirstChar { it.uppercase() }}"
+        openAILiveAudioViewModel.setVoice(selectedVoice)
+        openAILiveAudioViewModel.setTools(getAvailableTools())
+        openAILiveAudioViewModel.toolHandler = this
 
         // Initialize the views
         arguments?.getString("recognized_text")?.let { text ->
@@ -1414,8 +1418,12 @@ class ChatFragment : Fragment() {
 
     // In ChatFragment.kt
 
+    override suspend fun executeTool(functionName: String, argumentsJson: String): String {
+        return executeToolFunction(functionName, argumentsJson)
+    }
+
     // --- Tool Execution Router ---
-    private suspend fun executeToolFunction(functionName: String, argumentsJsonString: String): String {
+    suspend fun executeToolFunction(functionName: String, argumentsJsonString: String): String {
         return try {
             val arguments = JSONObject(argumentsJsonString)
             Log.i("ChatFragmentTool", "Executing tool: $functionName with args: $arguments")
@@ -4188,6 +4196,7 @@ class ChatFragment : Fragment() {
         selectedVoice = voice
         saveSelectedVoice(voice)
         binding.voiceSelectionButton.text = "🎙️ ${voice.replaceFirstChar { it.uppercase() }}"
+        openAILiveAudioViewModel.setVoice(voice)
     }
 
     private fun updateTtsButtonState() {

--- a/app/src/main/java/com/playstudio/AITeacher/ChatFragment.kt
+++ b/app/src/main/java/com/playstudio/AITeacher/ChatFragment.kt
@@ -1689,21 +1689,27 @@ class ChatFragment : Fragment(), VoiceToolHandler {
 
         val intent = Intent(AlarmClock.ACTION_SET_ALARM).apply {
             putExtra(AlarmClock.EXTRA_HOUR, hour)
-            putExtra(AlarmClock.EXTRA_MINUTES, minute) // Use the same import pattern
+            putExtra(AlarmClock.EXTRA_MINUTES, minute)
             putExtra(AlarmClock.EXTRA_MESSAGE, alarmMessage)
-            putExtra(AlarmClock.EXTRA_SKIP_UI, false) // Let user see the clock app UI to confirm/save
+            putExtra(AlarmClock.EXTRA_SKIP_UI, true) // Avoid leaving the app
 
             if (!daysOfWeek.isNullOrEmpty()) {
-                val calendarDays = ArrayList(daysOfWeek) // Assumes daysOfWeek contains Calendar.MONDAY, etc.
+                val calendarDays = ArrayList(daysOfWeek)
                 putExtra(AlarmClock.EXTRA_DAYS, calendarDays)
             }
         }
 
-        try {
+        return@withContext try {
             startActivity(intent)
-            JSONObject().apply { put("status", "success"); put("message", "Clock app opened to set alarm for ${String.format("%02d:%02d", hour, minute)}. Please confirm and save it there.") }.toString()
+            JSONObject().apply {
+                put("status", "success")
+                put("message", "Alarm set for ${String.format("%02d:%02d", hour, minute)}.")
+            }.toString()
         } catch (e: ActivityNotFoundException) {
-            JSONObject().apply { put("status", "error"); put("message", "No clock app found to set the alarm.") }.toString()
+            JSONObject().apply {
+                put("status", "error")
+                put("message", "No clock app found to set the alarm.")
+            }.toString()
         }
     }
 

--- a/app/src/main/java/com/playstudio/AITeacher/ChatFragment.kt
+++ b/app/src/main/java/com/playstudio/AITeacher/ChatFragment.kt
@@ -2399,13 +2399,16 @@ class ChatFragment : Fragment(), VoiceToolHandler {
                 if (hasOpenAICitations && !augmentedByCustomWebSearch) {
                     // Prepend "Web Search Results" only if OpenAI citations exist and no custom search augmented it.
                     val prefix = "🔍 Official Search Results:\n\n"
-                    processedContent = prefix + originalReplyContent // Use originalReplyContent for prefixing
-                    // Adjust indices for openAIProvidedCitations if prefixing 'originalReplyContent'
-                    finalCitations.forEach {
-                        // This needs careful index math if citations refer to 'originalReplyContent'
-                        // it.startIndex += prefix.length
-                        // it.endIndex += prefix.length
+                    processedContent = prefix + originalReplyContent
+                    // Adjust citation indices to account for the prefix so links remain clickable
+                    val adjusted = finalCitations.map {
+                        it.copy(
+                            startIndex = it.startIndex + prefix.length,
+                            endIndex = it.endIndex + prefix.length
+                        )
                     }
+                    finalCitations.clear()
+                    finalCitations.addAll(adjusted)
                 }
                 // If augmentedByCustomWebSearch is true, processedContent already has the enhanced text.
 

--- a/app/src/main/java/com/playstudio/AITeacher/ChatFragment.kt
+++ b/app/src/main/java/com/playstudio/AITeacher/ChatFragment.kt
@@ -523,10 +523,10 @@ class ChatFragment : Fragment(), VoiceToolHandler {
         // Show voice command tips on first launch
         val sharedPreferences = requireContext().getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
         if (sharedPreferences.getBoolean(FIRST_LAUNCH_KEY, true)) {
-            showVoiceFeaturesDialog()
             viewLifecycleOwner.lifecycleScope.launch {
-                delay(500)
                 handleTextToSpeech(getString(R.string.voice_greeting), force = true)
+                delay(4000)
+                showVoiceFeaturesDialog()
             }
             sharedPreferences.edit()
                 .putBoolean(FIRST_LAUNCH_KEY, false)

--- a/app/src/main/java/com/playstudio/AITeacher/ChatFragment.kt
+++ b/app/src/main/java/com/playstudio/AITeacher/ChatFragment.kt
@@ -2222,8 +2222,6 @@ class ChatFragment : Fragment(), VoiceToolHandler {
                     binding.recyclerView.smoothScrollToPosition(chatMessages.size - 1)
                 }
             }
-            // Force redraw in case DiffUtil misses updates
-            chatAdapter.notifyDataSetChanged()
         }
         if (!chatMessage.isTyping) {
             saveChatHistory()

--- a/app/src/main/java/com/playstudio/AITeacher/ChatFragment.kt
+++ b/app/src/main/java/com/playstudio/AITeacher/ChatFragment.kt
@@ -524,6 +524,10 @@ class ChatFragment : Fragment(), VoiceToolHandler {
         val sharedPreferences = requireContext().getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
         if (sharedPreferences.getBoolean(FIRST_LAUNCH_KEY, true)) {
             showVoiceFeaturesDialog()
+            viewLifecycleOwner.lifecycleScope.launch {
+                delay(500)
+                handleTextToSpeech(getString(R.string.voice_greeting), force = true)
+            }
             sharedPreferences.edit()
                 .putBoolean(FIRST_LAUNCH_KEY, false)
                 .putBoolean(VOICE_DIALOG_SHOWN_KEY, true)
@@ -4175,8 +4179,8 @@ class ChatFragment : Fragment(), VoiceToolHandler {
         }
     }
 
-    private fun handleTextToSpeech(text: String) {
-        if (isTtsEnabled) {
+    private fun handleTextToSpeech(text: String, force: Boolean = false) {
+        if (isTtsEnabled || force) {
             val json = JSONObject().apply {
                 put("model", "tts-1")
                 put("input", text)

--- a/app/src/main/java/com/playstudio/AITeacher/MainActivity.kt
+++ b/app/src/main/java/com/playstudio/AITeacher/MainActivity.kt
@@ -2860,10 +2860,12 @@ class MainActivity : AppCompatActivity(), PurchasesUpdatedListener, ChatFragment
 
     private fun openGenericEmailPicker() {
         try {
-            val intent = Intent(Intent.ACTION_PICK).apply {
+            val intent = Intent(Intent.ACTION_OPEN_DOCUMENT).apply {
+                addCategory(Intent.CATEGORY_OPENABLE)
                 type = "message/rfc822"
+                addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
             }
-            startActivityForResult(intent, EmailProviderHelper.EMAIL_PICK_REQUEST) // Use constant from helper
+            startActivityForResult(intent, EmailProviderHelper.EMAIL_PICK_REQUEST)
         } catch (e: ActivityNotFoundException) {
             Toast.makeText(this, "No email app found", Toast.LENGTH_SHORT).show()
             // Alternative approach for devices without email picker
@@ -2871,16 +2873,15 @@ class MainActivity : AppCompatActivity(), PurchasesUpdatedListener, ChatFragment
         }
     }
     private fun openEmailClient(account: Account? = null) {
-        // The 'account' parameter is often not directly usable with a generic ACTION_PICK intent.
-        // Email clients typically don't filter by a passed Account object for ACTION_PICK.
-        // The main purpose here is to launch an email picker.
-        val intent = Intent(Intent.ACTION_PICK).apply {
+        val intent = Intent(Intent.ACTION_OPEN_DOCUMENT).apply {
+            addCategory(Intent.CATEGORY_OPENABLE)
             type = "message/rfc822"
-            // Passing 'account' as an extra is non-standard and likely ignored by most email apps for ACTION_PICK.
-            // if (account != null) { intent.putExtra("account", account) }
+            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+            // Passing 'account' as an extra is non-standard and likely ignored
+            // by most email apps for ACTION_OPEN_DOCUMENT, so it's omitted.
         }
         try {
-            startActivityForResult(intent, EmailProviderHelper.EMAIL_PICK_REQUEST) // Use constant from helper
+            startActivityForResult(intent, EmailProviderHelper.EMAIL_PICK_REQUEST)
         } catch (e: ActivityNotFoundException) {
             Toast.makeText(this, "No email app found", Toast.LENGTH_SHORT).show()
         }

--- a/app/src/main/java/com/playstudio/AITeacher/VoiceFeaturesDialog.kt
+++ b/app/src/main/java/com/playstudio/AITeacher/VoiceFeaturesDialog.kt
@@ -1,0 +1,18 @@
+package com.playstudio.aiteacher
+
+import android.app.Dialog
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.widget.Button
+import androidx.appcompat.app.AlertDialog
+import androidx.fragment.app.DialogFragment
+
+class VoiceFeaturesDialog : DialogFragment() {
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        val view = LayoutInflater.from(requireContext()).inflate(R.layout.dialog_voice_features, null)
+        view.findViewById<Button>(R.id.btn_close_voice).setOnClickListener { dismiss() }
+        return AlertDialog.Builder(requireContext())
+            .setView(view)
+            .create()
+    }
+}

--- a/app/src/main/java/com/playstudio/AITeacher/VoiceFeaturesDialog.kt
+++ b/app/src/main/java/com/playstudio/AITeacher/VoiceFeaturesDialog.kt
@@ -4,13 +4,15 @@ import android.app.Dialog
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.widget.Button
+import android.widget.TextView
 import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.DialogFragment
 
 class VoiceFeaturesDialog : DialogFragment() {
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
-        val view = LayoutInflater.from(requireContext()).inflate(R.layout.dialog_voice_features, null)
-        view.findViewById<Button>(R.id.btn_close_voice).setOnClickListener { dismiss() }
+        val view = LayoutInflater.from(requireContext()).inflate(R.layout.dialog_promotion, null)
+        view.findViewById<TextView>(R.id.promotionMessage).text = getString(R.string.voice_features_dialog_message)
+        view.findViewById<Button>(R.id.btnClose).setOnClickListener { dismiss() }
         return AlertDialog.Builder(requireContext())
             .setView(view)
             .create()

--- a/app/src/main/java/com/playstudio/AITeacher/VoiceToolHandler.kt
+++ b/app/src/main/java/com/playstudio/AITeacher/VoiceToolHandler.kt
@@ -1,0 +1,5 @@
+package com.playstudio.aiteacher
+
+interface VoiceToolHandler {
+    suspend fun executeTool(functionName: String, argumentsJson: String): String
+}

--- a/app/src/main/res/layout/dialog_voice_features.xml
+++ b/app/src/main/res/layout/dialog_voice_features.xml
@@ -22,7 +22,7 @@
         android:id="@+id/voice_feature_message"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="You can now set alarms, send emails or open your calendar just by speaking. The conversation continues smoothly after each command."
+        android:text="Switch to OpenAI Realtime voice to set alarms, send emails and keep the conversation flowing. Live smart! 😊"
         android:textColor="@color/white"
         android:textSize="16sp"
         android:fontFamily="@font/montserrat_medium"

--- a/app/src/main/res/layout/dialog_voice_features.xml
+++ b/app/src/main/res/layout/dialog_voice_features.xml
@@ -22,7 +22,7 @@
         android:id="@+id/voice_feature_message"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="Switch to OpenAI Realtime voice to set alarms, send emails and keep the conversation flowing. Live smart! 😊"
+        android:text="@string/voice_features_dialog_message"
         android:textColor="@color/white"
         android:textSize="16sp"
         android:fontFamily="@font/montserrat_medium"

--- a/app/src/main/res/layout/dialog_voice_features.xml
+++ b/app/src/main/res/layout/dialog_voice_features.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="280dp"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="24dp"
+    android:background="@drawable/premium_dialog_background"
+    android:elevation="8dp">
+
+    <TextView
+        android:id="@+id/voice_feature_title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Voice Commands"
+        android:textColor="@color/premium_gold"
+        android:textSize="20sp"
+        android:textStyle="bold"
+        android:fontFamily="@font/montserrat_bold"
+        android:layout_marginBottom="12dp" />
+
+    <TextView
+        android:id="@+id/voice_feature_message"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="You can now set alarms, send emails or open your calendar just by speaking. The conversation continues smoothly after each command."
+        android:textColor="@color/white"
+        android:textSize="16sp"
+        android:fontFamily="@font/montserrat_medium"
+        android:lineSpacingExtra="4dp"
+        android:layout_marginBottom="24dp" />
+
+    <Button
+        android:id="@+id/btn_close_voice"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Got it!"
+        android:textAllCaps="true"
+        android:textSize="16sp"
+        android:textStyle="bold"
+        android:fontFamily="@font/montserrat_bold"
+        android:textColor="@color/white"
+        android:background="@drawable/button_premium_gradient"
+        android:paddingVertical="12dp" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/fragment_chat.xml
+++ b/app/src/main/res/layout/fragment_chat.xml
@@ -141,24 +141,17 @@
         </LinearLayout>
 
         <!-- Chat messages area -->
-        <ScrollView
-            android:id="@+id/chatScrollView"
+        <LinearLayout
+            android:id="@+id/chatContainer"
             android:layout_width="0dp"
             android:layout_height="0dp"
             app:layout_constraintTop_toBottomOf="@id/imageEditControls"
             app:layout_constraintBottom_toTopOf="@id/messageInputLayout"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
-            android:fillViewport="true"
-            android:contentDescription="@string/chat_scroll_view_desc">
-
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:orientation="vertical"
-                android:padding="16dp"
-                android:layout_gravity="center_horizontal"
-                android:contentDescription="@string/chat_linear_layout_desc">
+            android:orientation="vertical"
+            android:padding="16dp"
+            android:contentDescription="@string/chat_linear_layout_desc">
 
                 <!-- Chat messages RecyclerView -->
                 <LinearLayout
@@ -253,7 +246,6 @@
 
                 <!-- Generated images section -->
             </LinearLayout>
-        </ScrollView>
 
         <!-- Message input area - Calming blue gradient -->
         <androidx.constraintlayout.widget.ConstraintLayout

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -70,6 +70,7 @@
     <string name="openai_status_desc">Current status of OpenAI session</string>
     <string name="openai_response_desc">AI generated response</string>
     <string name="openai_controls_container">OpenAI voice controls</string>
+    <string name="voice_greeting">Welcome to AITeacher! You can control the app using your voice to set alarms, send emails and more.</string>
 
     <!-- Computer Use Strings -->
     <string name="start_computer_use">Start Computer Use</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -71,7 +71,7 @@
     <string name="openai_response_desc">AI generated response</string>
     <string name="openai_controls_container">OpenAI voice controls</string>
     <string name="voice_greeting">Welcome to AITeacher! Enable OpenAI Realtime voice in settings to chat naturally with AI and use voice commands for alarms, emails and more. Live smart! 😊</string>
-    <string name="voice_features_dialog_message">Open your device voice settings and choose OpenAI Realtime voice. Then you can talk with AI like another person and use commands to set alarms or send email. Live smart! 😊</string>
+    <string name="voice_features_dialog_message">Switch to GPT‑4o, Claude 4 or DeepSeek for powerful explanations or DALL\u00b7E to create stunning images. Live smart! \ud83d\ude0a</string>
 
     <!-- Computer Use Strings -->
     <string name="start_computer_use">Start Computer Use</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -70,7 +70,8 @@
     <string name="openai_status_desc">Current status of OpenAI session</string>
     <string name="openai_response_desc">AI generated response</string>
     <string name="openai_controls_container">OpenAI voice controls</string>
-    <string name="voice_greeting">Welcome to AITeacher! Switch to OpenAI Realtime voice to set alarms, send emails and more. Live smart! 😊</string>
+    <string name="voice_greeting">Welcome to AITeacher! Enable OpenAI Realtime voice in settings to chat naturally with AI and use voice commands for alarms, emails and more. Live smart! 😊</string>
+    <string name="voice_features_dialog_message">Open your device voice settings and choose OpenAI Realtime voice. Then you can talk with AI like another person and use commands to set alarms or send email. Live smart! 😊</string>
 
     <!-- Computer Use Strings -->
     <string name="start_computer_use">Start Computer Use</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -70,7 +70,7 @@
     <string name="openai_status_desc">Current status of OpenAI session</string>
     <string name="openai_response_desc">AI generated response</string>
     <string name="openai_controls_container">OpenAI voice controls</string>
-    <string name="voice_greeting">Welcome to AITeacher! You can control the app using your voice to set alarms, send emails and more.</string>
+    <string name="voice_greeting">Welcome to AITeacher! Switch to OpenAI Realtime voice to set alarms, send emails and more. Live smart! 😊</string>
 
     <!-- Computer Use Strings -->
     <string name="start_computer_use">Start Computer Use</string>


### PR DESCRIPTION
## Summary
- add a `VoiceToolHandler` interface for executing tool functions via voice
- let `ChatFragment` implement `VoiceToolHandler`
- configure `OpenAILiveAudioViewModel` with selected voice, available tools, and handler
- process function calls from Realtime API and trigger tools

## Testing
- `./gradlew assembleDebug` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_b_68473879bd0483259e5da9283cd314e3