### PR TITLE
Add Jest setup with Firestore and OpenAI chat test

### DIFF
--- a/functions/index.test.js
+++ b/functions/index.test.js
@@ -1,0 +1,64 @@
+const admin = require('firebase-admin');
+
+// Prepare OpenAI mock instance
+const openaiInstance = {
+  chat: {
+    completions: {
+      create: jest.fn().mockResolvedValue({
+        choices: [{ message: { content: 'mock reply' } }]
+      })
+    }
+  }
+};
+
+jest.mock('openai', () => {
+  return { OpenAI: jest.fn(() => openaiInstance) };
+});
+
+describe('chat cloud function', () => {
+  let chat;
+  let messages;
+  let docMock;
+
+  beforeAll(() => {
+    messages = [];
+    docMock = {
+      get: jest.fn().mockImplementation(() => Promise.resolve({
+        exists: messages.length > 0,
+        data: () => ({ messages: [...messages] })
+      })),
+      set: jest.fn().mockImplementation(data => {
+        messages = [...data.messages];
+        return Promise.resolve();
+      }),
+      delete: jest.fn()
+    };
+
+    const firestoreMock = {
+      collection: jest.fn().mockReturnValue({
+        doc: jest.fn().mockReturnValue(docMock)
+      })
+    };
+
+    jest.spyOn(admin, 'firestore').mockReturnValue(firestoreMock);
+    jest.spyOn(admin, 'initializeApp').mockImplementation(() => {});
+
+    chat = require('./index').chat;
+  });
+
+  beforeEach(() => {
+    messages.length = 0;
+  });
+
+  test('stores no more than six messages after replying', async () => {
+    for (let i = 1; i <= 3; i++) {
+      messages.push({ role: 'user', content: `u${i}` });
+      messages.push({ role: 'assistant', content: `a${i}` });
+    }
+
+    const context = { auth: { uid: 'user1' } };
+    await chat({ message: 'hello' }, context);
+
+    expect(messages.length).toBeLessThanOrEqual(6);
+  });
+});

--- a/functions/package.json
+++ b/functions/package.json
@@ -7,7 +7,8 @@
     "shell": "firebase functions:shell",
     "start": "npm run shell",
     "deploy": "firebase deploy --only functions",
-    "logs": "firebase functions:log"
+    "logs": "firebase functions:log",
+    "test": "jest"
   },
   "engines": {
     "node": "22"
@@ -24,7 +25,11 @@
     "cross-env": "^7.0.3",
     "eslint": "^8.15.0",
     "eslint-config-google": "^0.14.0",
-    "firebase-functions-test": "^3.1.0"
+    "firebase-functions-test": "^3.1.0",
+    "jest": "^29.7.0"
+  },
+  "jest": {
+    "testEnvironment": "node"
   },
   "private": true
 }


### PR DESCRIPTION
## Summary
- configure Jest for the Firebase functions package
- add a unit test for the `chat` function verifying conversation history is capped at six entries

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c4d9d5f0c8327adb3f8ae0fdcd2c2